### PR TITLE
Fix keychron.service

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,13 @@ Open a terminal window and enter the following command:
 
 Paste the following into the window:
 
-```[Unit]
+```
+[Unit]
 Description=The command to make the Keychron K2 work
 
 [Service]
 Type=oneshot
-ExecStart=echo 0 | sudo tee /sys/module/hid_apple/parameters/fnmode
+ExecStart=/bin/bash -c "echo 0 > /sys/module/hid_apple/parameters/fnmode"
 
 [Install]
 WantedBy=multi-user.target

--- a/script/keychron.service
+++ b/script/keychron.service
@@ -3,7 +3,7 @@ Description=The command to make the Keychron K2 work
 
 [Service]
 Type=oneshot
-ExecStart=echo 0 | sudo tee /sys/module/hid_apple/parameters/fnmode
+ExecStart=/bin/bash -c "echo 0 > /sys/module/hid_apple/parameters/fnmode"
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
I'm by no means an export in writing systemctl services, but there were a few things wrong with the current `keychron.service` according to my testing/research:

1. `ExecStart` expects an absolute bash, so `echo` would've never worked
2. `ExecStart` is not a full shell and does not support pipe as in `echo 0 | sudo tee ...`, the convention is to use `/bin/bash` to spawn a full shell and use `-c` to pass in the command that you would write normally

I also asked a StackExchange [question](https://unix.stackexchange.com/questions/599774/systemd-service-does-not-save-changes-to-disk) to help me understand why the old script didn't work

Tested on Ubuntu 18.04