### PR TITLE
rebooting isn't necessary

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,21 @@ Press `ctrl+o` and then `ctrl+x` to exit.
 
 ## Step 3
 
-In the terminal, type the following:
+In the terminal, first refresh your list of systemd-services by typing:
 
-`systemctl enable keychron`
+`systemctl daemon-reload`
+
+Then run the keychron service by typing:
+
+`systemctl start keychron`
+
+That's it! The function keys should now work.
 
 ## Step 4
 
-That's it! A reboot, and you'll see that the function keys have been re-enabled.
+For it to persist after a reboot you will need to enable the service. Type the following:
+
+`systemctl enable keychron`
 
 ## Closing Remarks
 


### PR DESCRIPTION
It isn't necessary to reboot immediately after setting up this service, you can just run it once and the function keys will work but you will still need to also run the enable command for it to automatically run whenever you actually reboot.

I've updated the readme with the commands to do that .