### PR TITLE
Update keychron.service

### DIFF
--- a/script/keychron.service
+++ b/script/keychron.service
@@ -2,8 +2,10 @@
 Description=Disable media keys and substitute in function keys
 
 [Service]
-Type=oneshot
+Type=simple
+RemainAfterExit=yes
 ExecStart=/bin/bash -c "echo 0 > /sys/module/hid_apple/parameters/fnmode"
+ExecStop=/bin/bash -c "echo 1 > /sys/module/hid_apple/parameters/fnmode"
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
I thought maybe it can be improved if you use a laptop. Just let it start automatically but if you need to disconnect the keychron because you're going to use the integrated keyboard (travel, conmuting...) then it would be nice to simply do `systemctl stop keychron` and restore the config.

The settings changed in the service file:

`Type=simple` (the default setting) is used when the process configured with `ExecStart `is the main process of the service. Such units will wait until the process specified by `ExecStart` returns, then deactivate by running the process specified by ExecStop.

With `RemainAfterExit=yes`, the service will be considered active even when all its processes have returned, and therefore the process specified by `ExecStop` will not run automatically. However, this setting is not recommended for real services since the service will still appear as being active even if it has crashed, but it is useful for our use case.